### PR TITLE
Support escaped math delimiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,15 +21,16 @@
   "author": "Susam Pal <susam@susam.in> (http://susam.in/)",
   "repository": "github:susam/texme",
   "dependencies": {
-    "commonmark": "latest"
+    "commonmark": "latest",
+    "esrever": "^0.2.0"
   },
   "devDependencies": {
+    "coveralls": "latest",
     "jsdoc": "latest",
     "jsdom": "latest",
     "mocha": "latest",
-    "sinon": "latest",
     "nyc": "latest",
-    "coveralls": "latest",
+    "sinon": "latest",
     "standard": "latest",
     "uglify-js": "latest"
   },

--- a/test/test-tokenize.js
+++ b/test/test-tokenize.js
@@ -24,6 +24,18 @@ describe('tokenize', function () {
     assert.deepStrictEqual(texme.tokenize(input), expected)
   })
 
+  it('math with escaped single dollars 1', function () {
+    var input = '\\$ 1 + 1 = 2 $'
+    var expected = [[MARK, input]]
+    assert.deepStrictEqual(texme.tokenize(input), expected)
+  })
+
+  it('math with escaped single dollars 2', function () {
+    var input = '$ 1 + 1 = 2 \\$'
+    var expected = [[MARK, input]]
+    assert.deepStrictEqual(texme.tokenize(input), expected)
+  })
+
   it('math with parentheses', function () {
     var input = '\\( 1 + 1 = 2 \\)'
     var expected = [[MASK, input]]


### PR DESCRIPTION
**Problem**
Currently, texme does not support escaped single dollar signs (`\$`). This means that if a user wants to include a dollar sign as text (e.g. "an apple costs $1"), it would get picked up as TeX. This is undesired, and MathJax already supports escaping single dollar signs via the `processEscapes` flag in the `tex2jax` config.

**Solution**
The `tokenize` function has been refactored such that it ignores escaped single dollar signs. This would have been a trivial change to the Regex for '$..$', but unfortunately the perfect regex requires regex lookbehind which is currently only supported on Chrome (see [this SO post](https://stackoverflow.com/questions/30118815/why-are-lookbehind-assertions-not-supported-in-javascript) for further information). 

The least invasive solution I found was to first reverse the entire input string and then apply a new regex for '$..$' which only requires regex lookahead (available on all browsers). Then, reverse all the tokens again at the end of the function.

A dependency to [esrever](https://github.com/mathiasbynens/esrever) was added to avoid unicode issues while reversing strings.

**Alternative Solutions**
Any other solutions I could come up with would have involved another layer of tokenization. I believe the current solution to be the simplest thing to do until regex lookbehind is supported across all browsers.

**Perfect Regex**
For future reference, the perfect regex with lookbehind is `(?<!\\)\$[\s\S]*?(?<!\\)\$`.